### PR TITLE
Only audit AKS clusters for privilege escalation

### DIFF
--- a/root/swdemo (swdemo)/swdemo-landingzones (swdemo-landingzones)/microsoft.authorization_policyassignments-deny-priv-esc-aks.json
+++ b/root/swdemo (swdemo)/swdemo-landingzones (swdemo-landingzones)/microsoft.authorization_policyassignments-deny-priv-esc-aks.json
@@ -19,7 +19,7 @@
         "NotScopes": null,
         "DisplayName": "Kubernetes clusters should not allow container privilege escalation",
         "Description": "Do not allow containers to run with privilege escalation to root in a Kubernetes cluster. This recommendation is part of CIS 5.2.5 which is intended to improve the security of your Kubernetes environments. This policy is generally available for Kubernetes Service (AKS), and preview for AKS Engine and Azure Arc enabled Kubernetes. For more information, see https://aka.ms/kubepolicydoc.",
-        "EnforcementMode": "Default",
+        "EnforcementMode": "DoNotEnforce",
         "PolicyDefinitionId": "/providers/Microsoft.Authorization/policyDefinitions/1c6e92c9-99f0-4e55-9cf2-0c234dc48f99",
         "Parameters": {
           "effect": {


### PR DESCRIPTION
To allow for a smoother onboarding of clusters